### PR TITLE
Fix a warning for becoming a standard library

### DIFF
--- a/dbg-rb.gemspec
+++ b/dbg-rb.gemspec
@@ -16,6 +16,7 @@ Gem::Specification.new do |s|
   s.license = "MIT"
   s.add_dependency "binding_of_caller"
   s.add_dependency "json"
+  s.add_development_dependency "ostruct"
   s.add_development_dependency "rake"
   s.add_development_dependency "rspec"
   s.add_development_dependency "rufo"


### PR DESCRIPTION
Just fixing warning.
If we are using Ruby 3.4.1 and run `bundle exec rake`, we will get the following warning:
```
❯ bundle exec rake
/ydah/dbg-rb/spec/smoke_spec.rb:5: warning: ostruct was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.
You can add ostruct to your Gemfile or gemspec to silence this warning.
```